### PR TITLE
Containerized gfoRmula

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM rocker/r-ver:latest
+  
+RUN install2.r --error gfoRmula


### PR DESCRIPTION
I made a docker image to containerize gforRmula, so it is easier to install across different computers. Nothing too crazy but I thought I would share.

As you can see from the command below I had to specify a larger memory to build the image because the packages take up a lot of space: 

docker build -t nrezaee/gformula . --memory 3g


The image is public at https://hub.docker.com/repository/docker/nrezaee/gformula#