### PR TITLE
Suggested error catch and message

### DIFF
--- a/R/pred.R
+++ b/R/pred.R
@@ -414,7 +414,13 @@ pred_fun_Y <- function(model, yrestrictions, outcome_type, outcome_name,
     fitY <- stats::glm(model, family = outcome_fam, data = obs_data, y = TRUE)
   }
   if(anyNA(coefficients(fitY))) {
-    stop("`NA` coefficients produced in prediction model. This may be due to (multi)collinearity in `ymodel` predictor variables, or including `time_name` variable in a 'continuous_eof' model.")
+    stop(
+      "`NA` coefficients produced in prediction model. ",
+      "This may be due to (multi)collinearity in `ymodel` predictor variables, ",
+      "or including `time_name` variable in a 'continuous_eof' model.\n",
+      "Variables returning `NA` coefficients:\n - ",
+      paste(names(coefficients(fitY)[is.na(coefficients(fitY))]), collapse = "\n - ")
+      )
   }
   fitY$rmse <- add_rmse(fitY)
   fitY$stderr <- add_stderr(fitY)

--- a/R/pred.R
+++ b/R/pred.R
@@ -413,6 +413,9 @@ pred_fun_Y <- function(model, yrestrictions, outcome_type, outcome_name,
     # Fit GLM for outcome variable using user-specified model and entire dataset
     fitY <- stats::glm(model, family = outcome_fam, data = obs_data, y = TRUE)
   }
+  if(anyNA(coefficients(fitY))) {
+    stop("`NA` coefficients produced in prediction model. This may be due to (multi)collinearity in `ymodel` predictor variables, or including `time_name` variable in a 'continuous_eof' model.")
+  }
   fitY$rmse <- add_rmse(fitY)
   fitY$stderr <- add_stderr(fitY)
   fitY$vcov <- add_vcov(fitY)

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -145,6 +145,28 @@ simulate <- function(o, fitcov, fitY, fitD,
                      min_time, show_progress, pb, int_visit_type, ...){
   set.seed(subseed)
 
+  invalid_coefs <- vapply(lapply(fitcov, coefficients), anyNA, logical(1)) |> any()
+
+  if (invalid_coefs) {
+
+    coefficients <- lapply(fitcov, coefficients)
+
+    errored_parts <- out_coefs[vapply(out_coefs, anyNA, logical(1))]  |>
+      lapply(\(coefs) {names(coefs[is.na(coefs)])})
+
+
+    paste(names(errored_parts), errored_parts, sep = "\n - ", collapse = "\n\n")
+
+    stop(
+        "`NA` coefficients produced in covariate prediction model. ",
+        "This may be due to (multi)collinearity in `covmodels` predictor variables, ",
+        "or including `time_name` variable in a 'continuous_eof' model.\n",
+        "Variables returning `NA` coefficients:\n",
+        paste(names(errored_parts), errored_parts, sep = "\n - ", collapse = "\n\n")
+    )
+
+  }
+
   # Mechanism of passing intervention variable and intervention is different for parallel
   # and non-parallel versions
   if (parallel){

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -151,7 +151,7 @@ simulate <- function(o, fitcov, fitY, fitD,
 
     coefficients <- lapply(fitcov, coefficients)
 
-    errored_parts <- out_coefs[vapply(out_coefs, anyNA, logical(1))]  |>
+    errored_parts <- coefficients[vapply(coefficients, anyNA, logical(1))]  |>
       lapply(\(coefs) {names(coefs[is.na(coefs)])})
 
 


### PR DESCRIPTION
Hello, I came across the same error message as in #20:

```
Error in seq.int(min(dim(R))) : 'from' must be a finite number
In addition: Warning message:
In min(dim(R)) : no non-missing arguments to min; returning Inf
```

This was being produced when `NA` coefficients were being returned by `stats::glm` in `pred_fun_Y`, which then breaks `stats::predict` in 'simulate.R'. This only happened when:
1. I included a time variable in `ymodel` in a "continuous_eof" model. I think I follow that this is because the model is being fitted at a single time point, therefore there's no variation in time across observations.
2. I include a custom variable - say a cumulative sum of A - alongside all lags of A. I presume here it's multicollinearity (as A and all lags of A perfectly predict the cumulative sum of A).
3. I included an unnecessary linear variable alongside the polynomial version (i.e. `~ A + stats::poly(A, 2)`), as R assigned `NA` to one of the duplicates (`A` or `A^1`)

So, my fault all round and I just need to understand the model better!

My suggestion here is to have a clearer message for tracking where this error is being produced and what might be causing it. A potential solution would be adding such an error checker to give clear suggestions. A rough skeleton could be: `"Error: NA coefficients produced in prediction model. This may be due to (multi)collinearity in ymodel predictor variables, or including time_name variable in a 'continuous_eof' model."`

That's just me hazarding a guess though. There may be clearer messages it'd be helpful to give, or even a more generic message merely that the model didn't provide a fit.

Example run with new error (produced by including `t0` in `ymodel`):
``` r
devtools::load_all()
#> ℹ Loading gfoRmula
library('Hmisc')
#> 
#> Attaching package: 'Hmisc'
#> 
#> The following objects are masked from 'package:base':
#> 
#>     format.pval, units
id <- 'id'
time_name <- 't0'
covnames <- c('L1', 'L2', 'A')
outcome_name <- 'Y'
outcome_type <- 'continuous_eof'
covtypes <- c('categorical', 'normal', 'binary')
histories <- c(lagged)
histvars <- list(c('A', 'L1', 'L2'))
covparams <- list(covmodels = c(L1 ~ lag1_A + lag1_L1 + L3 + t0 +
                                  rcspline.eval(lag1_L2, knots = c(-1, 0, 1)),
                                L2 ~ lag1_A + L1 + lag1_L1 + lag1_L2 + L3 + t0,
                                A ~ lag1_A + L1 + L2 + lag1_L1 + lag1_L2 + L3 + t0))
ymodel <- Y ~ A + L1 + L2 + lag1_A + lag1_L1 + lag1_L2 + L3 + t0
intvars <- list('A', 'A')
interventions <- list(list(c(static, rep(0, 7))),
                      list(c(static, rep(1, 7))))
int_descript <- c('Never treat', 'Always treat')
nsimul <- 10000

gform_cont_eof <- gformula(obs_data = continuous_eofdata,
                           id = id, time_name = time_name,
                           covnames = covnames, outcome_name = outcome_name,
                           outcome_type = outcome_type, covtypes = covtypes,
                           covparams = covparams, ymodel = ymodel,
                           intvars = intvars, interventions = interventions,
                           int_descript = int_descript,
                           histories = histories, histvars = histvars,
                           basecovs = c("L3"), nsimul = nsimul, seed = 1234)
#> Error in pred_fun_Y(ymodel, yrestrictions, outcome_type, outcome_name, : `NA` coefficients produced in prediction model. This may be due to (multi)collinearity in `ymodel` predictor variables, or including `time_name` variable in a 'continuous_eof' model.
```
